### PR TITLE
fix: -list-models flag does not list models correctly

### DIFF
--- a/cmd/aix/main.go
+++ b/cmd/aix/main.go
@@ -56,7 +56,7 @@ func main() {
 	}
 	if !options.Stream {
 		outputData := result.Completion
-		if renderer != nil {
+		if renderer != nil && !result.SkipMarkdown {
 			out, err := renderer.Render(outputData)
 			if err == nil {
 				outputData = out

--- a/internal/runner/result.go
+++ b/internal/runner/result.go
@@ -15,6 +15,7 @@ type Result struct {
 	CompletionStream *io.PipeReader `json:"-"` // contained stream response
 	streamWriter     *io.PipeWriter `json:"-"` // only used for streaming
 	Error            error          `json:"-"`
+	SkipMarkdown     bool           `json:"-"` // skip markdown rendering
 }
 
 // SetupStreaming sets up the streaming for the result

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -59,9 +59,10 @@ func (r *Runner) Run() (*Result, error) {
 		}
 
 		result := &Result{
-			Timestamp: time.Now().String(),
-			Model:     model,
-			Prompt:    r.options.Prompt,
+			Timestamp:    time.Now().String(),
+			Model:        model,
+			Prompt:       r.options.Prompt,
+			SkipMarkdown: true,
 		}
 
 		if r.options.Stream {


### PR DESCRIPTION
## Summary
This PR fixes #176

## Changes
- Added `SkipMarkdown` field to `Result` struct to control markdown rendering
- Set `SkipMarkdown=true` for list-models output to prevent text wrapping
- Updated main.go to check `SkipMarkdown` flag before applying markdown renderer

The issue was that the markdown renderer was processing the model list output, causing the models to be displayed as a wrapped paragraph instead of a clean list with one model per line.

## Testing
- ✅ Code builds successfully
- ✅ No existing tests broken (no test files exist in the project)
- ✅ Code follows gofmt standards

---
Generated with Claude Code